### PR TITLE
Initialize Shufflr app scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Shufflr.
+# Shufflr
+
+Initial scaffolding for the Shufflr desktop application using React, Tauri and TailwindCSS.
+
+## Development
+
+Install dependencies and start the Vite dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+The Tauri application can be started with:
+
+```bash
+npm run tauri dev
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shufflr</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body class="bg-slate-950 text-slate-200">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "shufflr",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "tauri": "tauri",
+    "tauri:dev": "tauri dev"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@google/generative-ai": "^0.5.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.24",
+    "@types/react-dom": "^18.0.8",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "@tailwindcss/forms": "^0.5.6",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@tauri-apps/cli": "^1.5.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "shufflr"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1", features = ["dialog", "fs", "path", "shell", "window"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+  tauri::Builder::default()
+    .run(tauri::generate_context!())
+    .expect("error while running tauri application");
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,30 @@
+{
+  "package": {
+    "productName": "Shufflr",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "title": "Shufflr",
+        "width": 1280,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
+      }
+    ],
+    "allowlist": {
+      "all": false,
+      "fs": {
+        "scope": ["$DOWNLOAD", "$DOCUMENT"],
+        "all": true
+      },
+      "dialog": true,
+      "path": true,
+      "shell": true,
+      "window": true
+    }
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import { FolderIcon, HelpCircleIcon, ShufflrLogoIcon } from './icons'
+
+export default function App() {
+  const [files] = useState([])
+  return (
+    <div className="flex flex-col h-screen text-slate-200 bg-slate-900">
+      <header
+        className="flex items-center justify-between px-4 py-2 backdrop-blur-sm bg-slate-800/60"
+        data-tauri-drag-region
+      >
+        <div className="flex items-center gap-2">
+          <ShufflrLogoIcon className="h-6 w-6 text-cyan-400" />
+          <span className="font-semibold">Shufflr</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button className="px-3 py-1 bg-cyan-600 text-white rounded flex items-center gap-1">
+            <FolderIcon className="h-5 w-5" />
+            Import Folder
+          </button>
+          <button className="p-2 hover:bg-slate-700 rounded">
+            <HelpCircleIcon className="h-5 w-5" />
+          </button>
+        </div>
+      </header>
+      <main className="flex-1 overflow-auto p-4">
+        {files.length === 0 && (
+          <p className="text-center text-slate-400">Import a folder to begin.</p>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react'
+
+function createIcon(path: string) {
+  return function Icon(props: SVGProps<SVGSVGElement>) {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...props}>
+        <path d={path} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    )
+  }
+}
+
+export const FolderIcon = createIcon('M3 7h5l2 3h11v11H3z')
+export const HelpCircleIcon = createIcon('M12 18h.01M9 9a3 3 0 116 0c0 1.5-1 2-1.5 2.5l-.5.5v2m0 0h.01')
+export const ShufflrLogoIcon = createIcon('M4 4h16v16H4z')

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './styles.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/src/services/fileUtils.ts
+++ b/src/services/fileUtils.ts
@@ -1,0 +1,19 @@
+import { readDir } from '@tauri-apps/api/fs'
+import type { FileInfo } from '../types'
+
+/**
+ * Recursively scan a directory using Tauri's fs.readDir API.
+ * Note: Tauri v1 does not expose file metadata such as size or
+ * modification date via the JS API, so placeholder values are used.
+ */
+export async function scanDirectory(path: string, recursive = false): Promise<FileInfo[]> {
+  const entries = await readDir(path, { recursive })
+  return entries.map((e, index) => ({
+    id: `${index}`,
+    name: e.name || '',
+    newName: e.name || '',
+    path: e.path,
+    size: undefined,
+    dateModified: undefined,
+  }))
+}

--- a/src/services/geminiService.ts
+++ b/src/services/geminiService.ts
@@ -1,0 +1,17 @@
+import { GoogleGenerativeAI } from '@google/generative-ai'
+
+const API_KEY = import.meta.env.VITE_API_KEY
+const genAI = new GoogleGenerativeAI(API_KEY)
+
+const DOCUMENTATION = `Shufflr Documentation\n\nThis is placeholder text for help.`
+
+export async function searchDocumentation(query: string): Promise<string> {
+  try {
+    const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' })
+    const result = await model.generateContent(`${DOCUMENTATION}\n\nQuestion: ${query}`)
+    return result.response.text()
+  } catch (err) {
+    console.error(err)
+    return 'An error occurred while searching the documentation.'
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  font-family: 'Inter', sans-serif;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+export interface FileInfo {
+  id: string
+  name: string
+  newName: string
+  path: string
+  size?: number
+  dateModified?: string
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}'
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [require('@tailwindcss/forms')],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- set up Tauri/React project skeleton with Vite and Tailwind
- add base UI layout and icon utilities
- stub file utilities and Gemini service
- provide basic Tauri configuration and build scripts

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68821c5114f88324971d0247be155754